### PR TITLE
The CDATA comments in adminhtml templates break minified html

### DIFF
--- a/src/view/adminhtml/templates/system/config/field/array.phtml
+++ b/src/view/adminhtml/templates/system/config/field/array.phtml
@@ -42,7 +42,6 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
 <script>
   require(['prototype', 'tinymce'], function (Prototype, tinyMCE) {
 
-    //<![CDATA[
     // create row creator
     var arrayRow<?php echo $_htmlId ?> = {
       // define row prototypeJS template
@@ -322,7 +321,6 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
       <?php if ($this->getElement()->getDisabled()):?>
     toggleValueElements({checked: true}, $('grid<?php echo $_htmlId ?>').parentNode);
       <?php endif;?>
-    //]]>
 
     window.arrayRow<?php echo $_htmlId ?> = arrayRow<?php echo $_htmlId ?>;
 

--- a/src/view/adminhtml/templates/system/config/field/card.phtml
+++ b/src/view/adminhtml/templates/system/config/field/card.phtml
@@ -38,7 +38,6 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
 <script>
   require(['prototype', 'tinymce'], function (Prototype, tinyMCE) {
 
-    //<![CDATA[
     // create row creator
     var arrayRow<?php echo $_htmlId ?> = {
       // define row prototypeJS template
@@ -309,7 +308,6 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
       <?php if ($this->getElement()->getDisabled()):?>
     toggleValueElements({checked: true}, $('grid<?php echo $_htmlId ?>').parentNode);
       <?php endif;?>
-    //]]>
 
     window.arrayRow<?php echo $_htmlId ?> = arrayRow<?php echo $_htmlId ?>;
 

--- a/src/view/adminhtml/templates/system/config/refresh.phtml
+++ b/src/view/adminhtml/templates/system/config/refresh.phtml
@@ -5,7 +5,6 @@
 <script>
   require(['prototype'], function () {
 
-    //<![CDATA[
     function refreshVerifonePayments() {
       var validationMessage = $('result');
 
@@ -43,7 +42,6 @@
     }
 
     window.refreshVerifonePayments = refreshVerifonePayments;
-    //]]>
 
   });
 </script>


### PR DESCRIPTION
Magento html minifier doesn't remove the CDATA comments from the templates. This causes the minified template to break all javascript after the CDATA comment since that code is also now commented out.

The CDATA comments should be unnecessary since the template file is unlikely to be interpreted as XML.

Steps to reproduce:
1. Clean Magento 2 installation
2. Install Verifone Payment
3. Turn on HTML Minification in the Magento settings
4. Navigate to the Payment Methods admin page. The console should have javascript error messages. Inspecting the html reveals that most of the JS coming from the adminhtml templates has been commented out by the CDATA comment.