### PR TITLE
Run additional validators before placing the order

### DIFF
--- a/src/view/frontend/web/js/view/payment/method-renderer/verifone-method.js
+++ b/src/view/frontend/web/js/view/payment/method-renderer/verifone-method.js
@@ -3,9 +3,10 @@ define(
         'jquery',
         'Magento_Checkout/js/view/payment/default',
         'Magento_Customer/js/model/customer',
-        'Magento_Checkout/js/action/place-order'
+        'Magento_Checkout/js/action/place-order',
+        'Magento_Checkout/js/model/payment/additional-validators'
     ],
-    function ($, Component, customer, placeOrderAction) {
+    function ($, Component, customer, placeOrderAction, additionalValidators) {
         'use strict';
 
         return Component.extend({
@@ -73,7 +74,7 @@ define(
                     $(loginFormSelector).validation();
                     emailValidationResult = Boolean($(loginFormSelector + ' input[name=username]').valid());
                 }
-                if (emailValidationResult && this.validate()) {
+                if (emailValidationResult && this.validate() && additionalValidators.validate()) {
                     this.isPlaceOrderActionAllowed(false);
                     placeOrder = placeOrderAction(this.getData(), this.redirectAfterPlaceOrder);
                     $.when(placeOrder).done(function () {


### PR DESCRIPTION
The Verifone payment method doesn't run the validators assigned to Magento_Checkout/js/model/payment/additional-validators component. This results in e.g. some shipping method validators not being run, making it possible to place orders with missing or bad data.