### PR TITLE
Fix trying to remove an unset header

### DIFF
--- a/src/Controller/AbstractPayment.php
+++ b/src/Controller/AbstractPayment.php
@@ -87,7 +87,9 @@ abstract class AbstractPayment extends Action
             if ($request instanceof Http && $request->isPost()) {
                 $headers = $request->getHeaders();
                 $header = $headers->get('X_REQUESTED_WITH');
-                $headers->removeHeader($header);
+                if ($header) {
+                    $headers->removeHeader($header);
+                }
             }
         }
     }


### PR DESCRIPTION
Calls to the Payment\Success controller were failing with the
following error:

TypeError: Argument 1 passed to Laminas\Http\Headers::removeHeader()
must implement interface Laminas\Http\Header\HeaderInterface, bool
given, called in
vendor/verifone/module-payment/src/Controller/AbstractPayment.php
on line 90 and defined in
vendor/laminas/laminas-http/src/Headers.php:249

It seems that in some cases the X-Requested-With header is not set
when the code removing it is executed. I was unable to easily
reproduce the issue, so this fix will only add code for corretly
handling the case where the header is not set without any major
investigation into underlying causes.